### PR TITLE
Correção tratamento tamanho de fonte

### DIFF
--- a/Source/RLMetaVCL.pas
+++ b/Source/RLMetaVCL.pas
@@ -681,7 +681,7 @@ end;
 procedure FontGetMetrics(const AFontName: AnsiString; AFontStyles: TFontStyles; var AFontRec: TRLMetaFontMetrics);
 var
   size: Integer;
-  outl: POutlineTextMetric;
+  outl: POutlineTextmetricA;
   I: Integer;
   bmp: TBitmap;
 begin
@@ -692,13 +692,13 @@ begin
   bmp.Canvas.Font.Style := AFontStyles;
   bmp.Canvas.Font.Size := 750;
   //
-  size := GetOutlineTextMetrics(bmp.Canvas.Handle, SizeOf(TOutlineTextmetricA), nil);
+  size := GetOutlineTextMetricsA(bmp.Canvas.Handle, SizeOf(TOutlineTextmetricA), nil);
   if size = 0 then
     raise Exception.Create('Invalid font for GetOutlineTextMetrics');
   GetMem(outl, size);
   try
     outl^.otmSize := size;
-    if GetOutlineTextMetrics(bmp.Canvas.Handle, size, outl) = 0 then
+    if GetOutlineTextMetricsA(bmp.Canvas.Handle, size, outl) = 0 then
       raise Exception.Create('GetOutlineTextMetrics failed');
     //
     AFontRec.TrueType := (outl^.otmTextMetrics.tmPitchAndFamily and TMPF_TRUETYPE) = TMPF_TRUETYPE;


### PR DESCRIPTION
Esta modificação corrige um bug que ocorre com a fonte 'Arial Narrow'. Os PDFs criados ficam com erro de não ter especificado o "/Widths" para a fonte, pos o 'FirstChar' e 'LastChar' retornados pela FontGetMetrics ficavam incorretos.