### PR TITLE
Compatibilizando a compilação para delphi2010

### DIFF
--- a/Source/RLXLSXFileFormat.pas
+++ b/Source/RLXLSXFileFormat.pas
@@ -46,9 +46,10 @@
 
 {$I RLReport.inc}
 
-{$IfNDef DELPHI8_UP}
- {$Define NO_SPLITSTRING}
+{$IfNDef DELPHIXE_UP}
+{$Define NO_SPLITSTRING}
 {$EndIf}
+
 {$IfDef FPC}
  {$Define NO_SPLITSTRING}
 {$EndIf}


### PR DESCRIPTION
Alterado de delphi8_up para delphiXE_up, até o delphi 2010 não existe a função splitString por padrão na strUtils.
Não sei dizer ao certo em qual versão foi implementado, só tenho o 2010 instalado.