### PR TITLE
Ajuste na quantidade de cópias de impressão.

### DIFF
--- a/Source/RLReport.pas
+++ b/Source/RLReport.pas
@@ -13471,7 +13471,7 @@ begin
     if Self.ReportState = rsReady then
       Dialog.MaxPage := Self.Pages.PageCount;
     Dialog.Orientation := Self.PageSetup.Orientation;
-    Dialog.Copies := 1;
+    Dialog.Copies := RLPrinter.Copies;
     Result := Dialog.Execute;
     if Result then
     begin


### PR DESCRIPTION
A quantidade de cópias do dialogo de impressão passou a respeitar o que
está em RLPrinter.Copies.