### PR TITLE
Corrigido erro do Scroll e Zoom do Formulario de Preview.

### DIFF
--- a/Source/RLAbout.pas
+++ b/Source/RLAbout.pas
@@ -63,9 +63,9 @@ uses
   {$Else}
    Types, Graphics, Controls, Forms, Dialogs, StdCtrls, ExtCtrls, Buttons,
   {$EndIf}
-  {$ifdef FPC}
+  {$IfDef FPC}
    LCLIntf, LCLType,
-  {$endif}
+  {$EndIf}
   RLConsts, RLUtils, RLComponentFactory;
 
 type

--- a/Source/RLDesign.pas
+++ b/Source/RLDesign.pas
@@ -56,17 +56,17 @@ uses
   {$IfDef FPC}
    PropEdits, ComponentEditors, LCLType, LResources,
   {$Else}
-   {$ifdef DELPHI5}
+   {$IfDef DELPHI5}
     DsgnIntF,
-   {$else}
+   {$Else}
     DesignEditors, DesignIntf,
-   {$endif}
-  {$endif}
-  {$ifdef CLX}
+   {$EndIf}
+  {$EndIf}
+  {$IfDef CLX}
    QForms,
   {$Else}
    Forms,
-  {$endif}
+  {$EndIf}
   RLReport, RLConsts, RLUtils, RLTypes, RLAbout;
 
 type

--- a/Source/RLDraftFilter.pas
+++ b/Source/RLDraftFilter.pas
@@ -54,16 +54,16 @@ interface
 
 uses
   {$IfDef MSWINDOWS}
-    Windows,
+   Windows,
   {$EndIf}
   SysUtils, Classes, Math, Contnrs,
   {$IfDef FPC}
-    LCLIntf, LCLType, IntfGraphics, FPImage, FileUtil, Process,
-    {$IfDef MSWINDOWS} WinUtilPrn, {$EndIf}
+   LCLIntf, LCLType, IntfGraphics, FPImage, FileUtil, Process,
+   {$IfDef MSWINDOWS} WinUtilPrn, {$EndIf}
   {$Else}
-    WinSpool, ShellApi,
+   WinSpool, ShellApi,
   {$EndIf}
-  {$ifdef CLX}
+  {$IfDef CLX}
    QGraphics, RLMetaCLX,
   {$Else}
    Graphics,

--- a/Source/RLHTMLFilter.pas
+++ b/Source/RLHTMLFilter.pas
@@ -53,11 +53,11 @@ interface
 
 uses
   SysUtils, Classes, Contnrs, Types,
-  {$ifdef CLX}
+  {$IfDef CLX}
    QGraphics, RLMetaCLX,
-  {$else}
+  {$Else}
    Graphics, RLMetaVCL,
-  {$endif}
+  {$EndIf}
   RLMetaFile, RLConsts, RLFilters, RLUtils, RLTypes;
 
 type

--- a/Source/RLPDFFilter.pas
+++ b/Source/RLPDFFilter.pas
@@ -61,13 +61,13 @@ uses
   {$IfDef FPC}
    LCLIntf, LCLType, LConvEncoding,
   {$Else}
-   {$IfDef DELPHIXE8_UP}Vcl.Imaging.jpeg{$Else}Jpeg{$EndIf},
+   {$IfDef DELPHIXE8_UP} Vcl.Imaging.jpeg {$Else} Jpeg {$EndIf},
   {$EndIf}
   {$IfDef CLX}
    QTypes, QGraphics, RLMetaCLX,
   {$Else}
    Types, Graphics, RLMetaVCL,
-  {$endif}
+  {$EndIf}
   RLMetaFile, RLConsts, RLTypes, RLUtils, RLFilters;
 
 const

--- a/Source/RLPkZip.pas
+++ b/Source/RLPkZip.pas
@@ -48,10 +48,9 @@
 
 {$Define SEARCHREC_USE_TIME}
 
-{$ifDef DELPHIXE7_UP}
-  {$UnDef SEARCHREC_USE_TIME}
+{$IfDef DELPHIXE7_UP}
+ {$UnDef SEARCHREC_USE_TIME}
 {$EndIf}
-
 
 unit RLPkZip;
 

--- a/Source/RLPreview.pas
+++ b/Source/RLPreview.pas
@@ -1,4 +1,4 @@
-{ Projeto: FortesReport Community Edition                                      }
+﻿{ Projeto: FortesReport Community Edition                                      }
 { É um poderoso gerador de relatórios disponível como um pacote de componentes }
 { para Delphi. Em FortesReport, os relatórios são constituídos por bandas que  }
 { têm funções específicas no fluxo de impressão. Você definir agrupamentos     }
@@ -61,7 +61,7 @@ uses
   Classes, SysUtils, Math, Contnrs,
   {$IfDef FPC}
    LCLIntf, LCLType,
-  {$ENDIF}
+  {$EndIf}
   {$IfDef CLX}
    QTypes, QGraphics, QControls, QExtCtrls, QForms, QMenus, QClipbrd, QDialogs,
   {$Else}

--- a/Source/RLPreviewForm.pas
+++ b/Source/RLPreviewForm.pas
@@ -53,16 +53,16 @@ interface
 
 uses
   {$IfDef MSWINDOWS}
-  Windows,
+   Windows,
   {$EndIf}
-  Messages, SysUtils, Math, Contnrs, Classes,
+   Messages, SysUtils, Math, Contnrs, Classes,
   {$IfDef FPC}
-  LMessages, LCLIntf, LCLType, FileUtil,
+   LMessages, LCLIntf, LCLType, FileUtil,
   {$EndIf}
   {$IfDef CLX}
-  QTypes, QControls, QButtons, QExtCtrls, QForms, QDialogs, QStdCtrls, QGraphics, Qt,
+   QTypes, QControls, QButtons, QExtCtrls, QForms, QDialogs, QStdCtrls, QGraphics, Qt,
   {$Else}
-  Types, Controls, Buttons, ExtCtrls, Forms, Dialogs, StdCtrls, Graphics,
+   Types, Controls, Buttons, ExtCtrls, Forms, Dialogs, StdCtrls, Graphics,
   {$EndIf}
   RLConsts, RLMetaFile, RLPreview, RLFilters, RLUtils, RLPrintDialog,
   RLSaveDialog, RLPrinters, RLTypes, RLFindDialog, RLComponentFactory;

--- a/Source/RLPreviewForm.pas
+++ b/Source/RLPreviewForm.pas
@@ -53,23 +53,23 @@ interface
 
 uses
   {$IfDef MSWINDOWS}
-   Windows,
+  Windows,
   {$EndIf}
   Messages, SysUtils, Math, Contnrs, Classes,
   {$IfDef FPC}
-   LMessages, LCLIntf, LCLType, FileUtil,
+  LMessages, LCLIntf, LCLType, FileUtil,
   {$EndIf}
   {$IfDef CLX}
-   QTypes, QControls, QButtons, QExtCtrls, QForms, QDialogs, QStdCtrls, QGraphics, Qt,
+  QTypes, QControls, QButtons, QExtCtrls, QForms, QDialogs, QStdCtrls, QGraphics, Qt,
   {$Else}
-   Types, Controls, Buttons, ExtCtrls, Forms, Dialogs, StdCtrls, Graphics,
+  Types, Controls, Buttons, ExtCtrls, Forms, Dialogs, StdCtrls, Graphics,
   {$EndIf}
   RLConsts, RLMetaFile, RLPreview, RLFilters, RLUtils, RLPrintDialog,
   RLSaveDialog, RLPrinters, RLTypes, RLFindDialog, RLComponentFactory;
 
 {$IfDef FPC}
 const
-  WM_MOUSEWHEEL = LM_MOUSEWHEEL;
+  CM_MOUSEWHEEL = LM_MOUSEWHEEL;
 {$EndIf}
 
 type
@@ -152,7 +152,7 @@ type
     procedure ShowFindDialog;
     procedure OnFindHandler(Sender: TObject; const Text: string; Options: TRLFindOptions; var Found: Boolean);
     procedure SpeedButtonCustomActionClick(Sender: TObject);
-    procedure CMMouseWheel(var Message: TMessage); message WM_MOUSEWHEEL;
+    procedure CMMouseWheel(var Message: TCMMouseWheel); message CM_MOUSEWHEEL;
   protected
     { Protected declarations }
     procedure DoClose(var Action: TCloseAction); override;
@@ -1802,16 +1802,16 @@ begin
     EnableWindow(Handle,True);
 end;
 
-procedure TRLPreviewForm.CMMouseWheel(var Message: TMessage);
+procedure TRLPreviewForm.CMMouseWheel(var Message: TCMMouseWheel);
 begin
   if GetKeyState(VK_CONTROL) < 0 then
   begin
-    if Message.wParam > 0 then
+    if Message.WheelDelta > 0 then
       Preview.ZoomIn
     else
       Preview.ZoomOut;
   end
-  else if Message.wParam > 0 then
+  else if Message.WheelDelta > 0 then
       Preview.ScrollUp
     else
       Preview.ScrollDown;

--- a/Source/RLPrinters.pas
+++ b/Source/RLPrinters.pas
@@ -67,7 +67,7 @@ uses
   {$EndIf}
   {$IfDef FPC}
    OSPrinters,
-   {$IfDef MSWINDOWS}WinUtilPrn,{$Else}process,{$EndIf}
+   {$IfDef MSWINDOWS} WinUtilPrn, {$Else} process, {$EndIf}
   {$EndIf}
   RLConsts, RLTypes, RLUtils;
 

--- a/Source/RLReg.pas
+++ b/Source/RLReg.pas
@@ -52,16 +52,18 @@ interface
 
 uses
   Classes, SysUtils,
-  {$ifdef FPC}
+  {$IfDef FPC}
    PropEdits, ComponentEditors, LCLType, LResources,
   {$Else}
-   {$ifdef DELPHI5}
-  DsgnIntF, 
-   {$else}
-  DesignIntF, 
-   {$endif}
-  {$endif}
-{$IFDEF DELPHI2007_UP}ToolsApi, Windows, Graphics,{$ENDIF}
+   {$IfDef DELPHI5}
+    DsgnIntF,
+   {$Else}
+    DesignIntF,
+   {$EndIf}
+  {$EndIf}
+  {$IfDef DELPHI2007_UP}
+   ToolsApi, Windows, Graphics,
+  {$EndIf}
   RLDesign, RLReport,
   RLDraftFilter, RLPDFFilter, RLHTMLFilter, RLRichFilter,
   RLParser, RLPreview, RLMetaFile, RLBarcode, RLRichText, RLPreviewForm,

--- a/Source/RLRichFilter.pas
+++ b/Source/RLRichFilter.pas
@@ -60,7 +60,7 @@ uses
   SysUtils, Classes, Types,
   {$IfDef FPC}
    LCLIntf,
-  {$endif}
+  {$EndIf}
   {$IfDef CLX}
    QGraphics, RLMetaCLX,
   {$Else}

--- a/Source/RLRichText.pas
+++ b/Source/RLRichText.pas
@@ -53,9 +53,9 @@ interface
 
 uses
   Classes, SysUtils, Contnrs, Math,
-  {$ifdef CLX}
+  {$IfDef CLX}
    QTypes, QGraphics, RLMetaCLX,
-  {$else}
+  {$Else}
    Types, Graphics, RLMetaVCL,
   {$EndIf}
   RLReport, RLUtils, RLMetaFile;

--- a/Source/RLSpoolFilter.pas
+++ b/Source/RLSpoolFilter.pas
@@ -62,10 +62,10 @@ uses
    QTypes, QGraphics, RLMetaCLX,
   {$else}
    Types, Graphics, RLMetaVCL,
-  {$endif}
-  {$ifdef FPC}
-    LCLIntf, LCLType,
-  {$endif}
+  {$EndIf}
+  {$IfDef FPC}
+   LCLIntf, LCLType,
+  {$EndIf}
   RLMetaFile, RLFilters, RLTypes, RLPrinters, RLConsts, RLUtils;
 
 type

--- a/Source/RLTypes.pas
+++ b/Source/RLTypes.pas
@@ -53,7 +53,7 @@ interface
 
 uses
   {$IfDef MSWINDOWS}
-    Windows, 
+   Windows,
   {$EndIf}
   Classes, Printers;
 

--- a/Source/RLUtils.pas
+++ b/Source/RLUtils.pas
@@ -56,7 +56,6 @@
  {$EndIf}
 {$EndIf}
 
-
 {@unit RLUtils - Rotinas de uso geral. }
 unit RLUtils;
 

--- a/Source/RLXLSFilter.pas
+++ b/Source/RLXLSFilter.pas
@@ -58,14 +58,14 @@ uses
   SysUtils, Classes, Contnrs,
   {$IfDef FPC}
    LCLIntf, LCLType,
-  {$endif}
-  {$ifdef CLX}
+  {$EndIf}
+  {$IfDef CLX}
    QTypes, QGraphics, RLMetaCLX,
   {$Else}
-    Types, Graphics, RLMetaVCL,
-    {$IfNDef FPC}
-     RlCompilerConsts,
-    {$EndIf}
+   Types, Graphics, RLMetaVCL,
+   {$IfNDef FPC}
+    RlCompilerConsts,
+   {$EndIf}
   {$EndIf}
   {$IfDef NATIVEEXCEL}
    nExcel,

--- a/Source/RLXLSXFileFormat.pas
+++ b/Source/RLXLSXFileFormat.pas
@@ -47,7 +47,7 @@
 {$I RLReport.inc}
 
 {$IfNDef DELPHIXE_UP}
-{$Define NO_SPLITSTRING}
+ {$Define NO_SPLITSTRING}
 {$EndIf}
 
 {$IfDef FPC}

--- a/Source/RLXLSXFilter.pas
+++ b/Source/RLXLSXFilter.pas
@@ -53,7 +53,6 @@
  {$DEFINE HAS_FORMATSETTINGS}
 {$EndIf}
 
-
 unit RLXLSXFilter;
 
 interface


### PR DESCRIPTION
O valor de _Message.wParam_ sempre maior que **zero** na interceptação da mensagem do sistema operacional através do método **CMMouseWheel** para _Message_ do tipo _TMessage_ acarretando sempre na chamada do método **Preview.ScrollUp**  ou **Preview.ZoomIn** caso a tecla **Ctrl** estivesse sendo pressionada. Mudou-se o tipo de _Message_ para _TCMMouseWheel_ permitindo controlar a chamada aos métodos através do valor contido em _WheelDelta_.