### PR TITLE
Corrigido falta de caractere no valor da variável LS_SendToStr da tradução para Francês.

### DIFF
--- a/Source/RLConsts.pas
+++ b/Source/RLConsts.pas
@@ -569,7 +569,7 @@ var
     LS_MultiplePagesStr: 'Plusieurs pages';
     LS_ConfigPrinterStr: 'Configuration de l''imprimante';
     LS_SaveToFileStr: 'Enregistrer dans un fichier';
-    LS_SendToStr: 'Envoyer à...;
+    LS_SendToStr: 'Envoyer à...';
     LS_PrinterStr: 'Imprimante';
     LS_NameStr: 'Nom';
     LS_PrintToFileStr: 'Imprimer dans un fichier';


### PR DESCRIPTION
Adicionado caractere aspas simples ao final do valor atribuído a variável _LS_SendToStr_ da tradução para Francês.