### PR TITLE
Fixes a problem where calling DocumentProperties could fail

### DIFF
--- a/Source/RLPrinters.pas
+++ b/Source/RLPrinters.pas
@@ -966,7 +966,9 @@ begin
   try
     OldDeviceMode := GlobalLock(OldModeHandle);
     try
-      BytesNeeded := WinSpool.DocumentProperties(WindowHandle, PrinterHandle, Device, NewDeviceMode^, OldDeviceMode^, 0);
+      BytesNeeded := WinSpool.DocumentProperties(WindowHandle, PrinterHandle, Device, nil, nil, 0);
+      if BytesNeeded < 0 then
+        raise Exception.Create('The call to DocumentProperties failed.');
       NewModeHandle := GlobalAlloc(GHND, BytesNeeded);
       NewDeviceMode := GlobalLock(NewModeHandle);
       try


### PR DESCRIPTION
…n -1 which in turn could lead to a range check exception. BytesNeeded gets checked now in case of other reasons for failures.