### PR TITLE
Exportação para XLSx

### DIFF
--- a/Source/RLXLSXFileFormat.pas
+++ b/Source/RLXLSXFileFormat.pas
@@ -1663,6 +1663,14 @@ begin
     for RowId := RowId1 to RowId2 do
     begin
       Row := FindRow(RowId, True);
+
+      if ColId1 > ColId2 then
+	    begin
+	      ColId := ColId1;
+    	  ColId1 := ColId2;
+	      ColId2 := ColId;
+	    end;
+	  
       for ColId := ColId1 to ColId2 do
       begin
         Cell := Row.FindCell(ColId, True);
@@ -1709,6 +1717,7 @@ begin
   Result := FindCell(RowId, ColId, True);
   Result.FValueType := TRLXLSXCellValueTypeFloat;
   Result.FValue.FloatValue := FloatValue;
+
 end;
 
 function TRLXLSXWorksheet.SetString(RowId, ColId: Integer; const StringValue: string): TRLXLSXCell;


### PR DESCRIPTION
Ao exportar o relatório para XLSx em algumas situações especificas, ocorria a tentativa de mesclar uma célula de coluna com índice inicial maior que o índice final. Como isso era feito num for, era retornado ponteiro nil para a coluna de resultado, visto que ele não passava no código. Ocorria então erro de violação de acesso. Quando essa situação ocorrer, é ncessário simplesmente inverter os indices iniciais e finais.