### PR TITLE
Fix wrong font widths for screens with more than 96 ppi.

### DIFF
--- a/Source/RLPDFFilter.pas
+++ b/Source/RLPDFFilter.pas
@@ -1480,7 +1480,7 @@ begin
           Writeln;
           W := 0;
         end;
-        Write(IntToStr(rec.Widths[J]) + ' ');
+        Write(IntToStr(MulDiv(rec.Widths[J], 96, ScreenPPI)) + ' ');
         Inc(W);
       end;
       Writeln;


### PR DESCRIPTION
Fixes #296 (and perhaps #126 and #128)