### PR TITLE
Compatibilidade Delphi 10.4

### DIFF
--- a/Source/RLDesign.pas
+++ b/Source/RLDesign.pas
@@ -65,7 +65,11 @@ uses
   {$IfDef CLX}
    QForms,
   {$Else}
-   Forms,
+   {$If CompilerVersion > 21}
+     Vcl.Forms,
+   {$Else}
+     Forms,
+   {$EndIf}
   {$EndIf}
   RLReport, RLConsts, RLUtils, RLTypes, RLAbout;
 

--- a/Source/RLDesign.pas
+++ b/Source/RLDesign.pas
@@ -69,7 +69,7 @@ uses
      Vcl.Forms,
    {$Else}
      Forms,
-   {$EndIf}
+   {$IfEnd}
   {$EndIf}
   RLReport, RLConsts, RLUtils, RLTypes, RLAbout;
 

--- a/Source/RLReg.pas
+++ b/Source/RLReg.pas
@@ -67,7 +67,7 @@ uses
    Vcl.Graphics,
    {$Else}
    Graphics,
-   {$EndIf}
+   {$IfEnd}
   {$EndIf}
   RLDesign, RLReport,
   RLDraftFilter, RLPDFFilter, RLHTMLFilter, RLRichFilter,

--- a/Source/RLReg.pas
+++ b/Source/RLReg.pas
@@ -62,7 +62,12 @@ uses
    {$EndIf}
   {$EndIf}
   {$IfDef DELPHI2007_UP}
-   ToolsApi, Windows, Graphics,
+   ToolsApi, Windows,
+   {$If CompilerVersion > 21}
+   Vcl.Graphics,
+   {$Else}
+   Graphics,
+   {$EndIf}
   {$EndIf}
   RLDesign, RLReport,
   RLDraftFilter, RLPDFFilter, RLHTMLFilter, RLRichFilter,


### PR DESCRIPTION
Estava testando o delphi na versão 10.4 e verifiquei que existe uma incompatibilidade com a biblioteca Graphics, por que o delphi mais novo possui mais de uma biblioteca Graphics, que são as FMX.Graphics e a VLC.Graphics, e também tem problemas com a biblioteca Forms. Então segue a correção a partir da versão Delphi XE.

E também verifiquei que os delphi antigos tem uma diferença de sintaxe onde a depender do if da diretiva de compilação se deve utilizar "EndIf" ou "IfEnd", então modifiquei de forma que ficasse compatível com ambos.

# Versões do Delphi
Delphi XE6 27 VER270
Delphi XE5 26 VER260
Delphi XE4 25 VER250
Delphi XE3 24 VER240
Delphi XE2 23 VER230
Delphi XE 22 VER220
Delphi 2010 21 VER210
Delphi 2009 20 VER200
Delphi 2007 .NET 19 VER190
Delphi 2007 18.5 VER185
Delphi 2006 18 VER180
Delphi 2005 17 VER170
Delphi 8 .NET 16 VER160
Delphi 7 15 VER150
Delphi 6 14 VER140
Delphi 5 13 VER130
Delphi 4 12 VER120
Delphi 3 10 VER100
Delphi 2 9 VER90
Delphi 1 8 VER80
