### PR TITLE
Correção de ML ao gerar relatório

### DIFF
--- a/Source/RLUtils.pas
+++ b/Source/RLUtils.pas
@@ -388,6 +388,9 @@ type
   TPublicGraphic = class(TGraphic)
   end;
 
+var
+  AuxBitmap: TBitmap;
+
 function HexToBitmap(const AHex: AnsiString): TBitmap;
 var
   stream: TStringStream;
@@ -404,7 +407,14 @@ begin
       Inc(I, 2);
     end;
     // procura referência para a classe
-    Result := NeedAuxBitmap;
+    if AuxBitmap <> nil then
+      AuxBitmap.Free;
+
+    AuxBitmap := TRLBitmap.Create;
+    AuxBitmap.Width := 1;
+    AuxBitmap.Height := 1;
+
+    Result := AuxBitmap;
     stream.Seek(0, 0);
     TPublicGraphic(Result).ReadData(stream);
   finally
@@ -1124,8 +1134,10 @@ end;
 initialization
   TempDir := GetTempDir;
   LogClear;
+  AuxBitmap := Nil;
 
 finalization
   ClearTempFiles;
+  FreeObj(AuxBitmap);
 
 end.  


### PR DESCRIPTION
Ao gerar um relatório estava ocorrendo um Memory Leak na função HexToBitmap.

Verifiquei o histórico de atualizações e percebi que foi realizada uma adequação na função NeedAuxBitmap para o funcionamento em Multithread, o que acabou afetando juntamente esta função.

Voltei o que tinha sido retirado com a adequação, mais em vez de deixar no geral da NeedAuxBitmap, deixei apenas para a função HexToBitmap